### PR TITLE
Fix issue where PanningInteractiveTransition occasionally fails to work

### DIFF
--- a/AnimatedTransitionKit.podspec
+++ b/AnimatedTransitionKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "AnimatedTransitionKit"
-  s.version          = "4.3.0"
+  s.version          = "4.3.1"
   s.summary          = "UIViewController Transitioning Library."
   s.description      = "This library helps you to apply and create Custom UIViewController Transitions."
   s.homepage         = "https://github.com/pisces/AnimatedTransitionKit"

--- a/AnimatedTransitionKit/Classes/Interactors/Base/AbstractInteractiveTransition.h
+++ b/AnimatedTransitionKit/Classes/Interactors/Base/AbstractInteractiveTransition.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSUInteger, InteractiveTransitionDirection) {
 @property (nullable, weak) AbstractTransition *transition;
 - (void)attach:(__weak UIViewController * _Nonnull)viewController;
 - (void)detach;
+- (void)clear;
 @end
 
 @protocol InteractiveTransitionDelegate <NSObject>

--- a/AnimatedTransitionKit/Classes/Interactors/Base/AbstractInteractiveTransition.m
+++ b/AnimatedTransitionKit/Classes/Interactors/Base/AbstractInteractiveTransition.m
@@ -63,6 +63,11 @@
     return self;
 }
 
+- (void)dealloc {
+    [self detach];
+    [self clear];
+}
+
 #pragma mark - Overridden: UIPercentDrivenInteractiveTransition
 
 - (void)cancelInteractiveTransition {
@@ -169,15 +174,15 @@
     _viewController = nil;
 }
 
-#pragma mark - Private methods
-
-- (void)completeInteraction {
-    [self.transition.transitioning endAnimating];
-
+- (void)clear {
     if (!_viewControllerForAppearing.parentViewController) {
         _viewControllerForAppearing = nil;
     }
+}
 
+#pragma mark - Private methods
+
+- (void)completeInteraction {
     if (self.shouldComplete) {
         if ([_delegate respondsToSelector:@selector(didCompleteWithInteractor:)]) {
             [_delegate didCompleteWithInteractor:self];

--- a/AnimatedTransitionKit/Classes/Interactors/Panning/PanningInteractiveTransition.m
+++ b/AnimatedTransitionKit/Classes/Interactors/Panning/PanningInteractiveTransition.m
@@ -96,10 +96,6 @@ const Percent PercentZero;
 
 #pragma mark - Con(De)structors
 
-- (void)dealloc {
-    [self detach];
-}
-
 - (id)init {
     self = [super init];
     if (self) {
@@ -118,6 +114,11 @@ const Percent PercentZero;
     if (self.drivingScrollView) {
         [self.drivingScrollView.panGestureRecognizer removeTarget:self action:@selector(panned:)];
     }
+}
+
+- (void)clear {
+    [super clear];
+    _startPanningDirection = PanningDirectionNone;
 }
 
 - (CGFloat)translationOffset {

--- a/AnimatedTransitionKit/Classes/Transitions/Base/AbstractAnimatedTransitioning.m
+++ b/AnimatedTransitionKit/Classes/Transitions/Base/AbstractAnimatedTransitioning.m
@@ -32,6 +32,11 @@
 
 #import "AbstractAnimatedTransitioning.h"
 #import "AbstractInteractiveTransition.h"
+#import "PanningInteractiveTransition.h"
+
+@interface AbstractAnimatedTransitioning ()
+@property (nullable, nonatomic, weak) AbstractInteractiveTransition* interactor;
+@end
 
 @implementation AbstractAnimatedTransitioning
 
@@ -41,7 +46,9 @@
     return _options.duration;
 }
 
-- (void)animationEnded:(BOOL)transitionCompleted { }
+- (void)animationEnded:(BOOL)transitionCompleted {
+    [self endAnimating];
+}
 
 - (void)animateTransition:(id <UIViewControllerContextTransitioning>)transitionContext {
     _context = transitionContext;
@@ -101,12 +108,16 @@
 - (void)clear { }
 
 - (void)endAnimating {
+    if (_interactor) {
+        [_interactor clear];
+    }
     _animating = NO;
     _percentOfInteraction = 0;
     _percentOfCompletion = 0;
 }
 
 - (void)interactionBegan:(AbstractInteractiveTransition * _Nonnull)interactor transitionContext:(id <UIViewControllerContextTransitioning> _Nonnull)transitionContext {
+    _interactor = interactor;
     _context = transitionContext;
 }
 


### PR DESCRIPTION
## Summary
- Add new function to clear into `AbstractInteractiveTransition` and call it needed
- Update podspec version to 4.3.1