### PR TITLE
ISSUE-85 > iPad split view support

### DIFF
--- a/AnimatedTransitionKit/Classes/Transitions/Move/MoveTransitioningProxy.swift
+++ b/AnimatedTransitionKit/Classes/Transitions/Move/MoveTransitioningProxy.swift
@@ -206,6 +206,7 @@ extension MoveTransitioningProxy {
         transitionContext: UIViewControllerContextTransitioning)
     {
         transitionContext.containerView.addSubview(toVC.view)
+        toVC.view.frame = transitionContext.finalFrame(for: toVC)
         fromVC.view.transform = belowViewTransformWhileSliding(percent: 0, transitionContext: transitionContext)
 
         let x = isVertical ? 0 : transitionContext.containerView.bounds.width


### PR DESCRIPTION
**Issue**
[Isssue - 85](https://github.com/pisces/AnimatedTransitionKit/issues/85)

**Description**
Adds  iPad split view support for `MoveTransitioningProxy`.
Previously, the presented viewController's view frame didn't correctly match the app's screenSize in split view mode.
Refer to the screenshot below for details on the resolved issue.

**screen shot**
Before | After
:-: | :-: |
<img width="387" height="1171" alt="before" src="https://github.com/user-attachments/assets/2840d9f6-100e-4771-88a9-f893d0ecfce3" /> | <img width="387" height="1171" alt="after" src="https://github.com/user-attachments/assets/54ed56fd-97f5-46e4-9296-0532d0e48213" />